### PR TITLE
Add MIT LICENSE file to match the README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Andreas Geert Motzfeldt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Hi 👋

The README states the project is released under the **MIT license**:

> "…releasing our code under the MIT license…"
> — `README.md`, *Ethical Considerations and Limitations* section

…but there's currently no `LICENSE` file, so GitHub doesn't recognize a license (the repo shows **License: None**) and the code defaults to *"all rights reserved."* This PR adds a standard MIT `LICENSE` file matching that stated intent, so the licensing is explicit and machine-detectable on GitHub.

**No code changes** — this only adds the license text.

A couple of things to double-check before merging:
- I set the copyright line to `2024-2026 Andreas Geert Motzfeldt` based on the repo author and commit history. **Please adjust** the holder (e.g. to Corti, or to include other contributors) and the year range as appropriate.
- You may optionally also want to add `license = { text = "MIT" }` (or a license classifier) to `pyproject.toml`.

Closes #18.

Thanks for the great work on this project!
